### PR TITLE
Add command line options for peppy.Project

### DIFF
--- a/eido/argparser.py
+++ b/eido/argparser.py
@@ -40,28 +40,30 @@ def build_argparser():
     )
     sps = {}
     for cmd, desc in SUBPARSER_MSGS.items():
-        sps[cmd] = subparsers.add_parser(cmd, description=desc, help=desc)
-        sps[cmd].add_argument(
+        subparser = subparsers.add_parser(cmd, description=desc, help=desc)
+        subparser.add_argument(
             "--st-index",
             required=False,
             type=str,
             help=f"Sample table index to use, samples are identified by '{SAMPLE_NAME_ATTR}' by default.",
         )
         if cmd != CONVERT_CMD:
-            sps[cmd].add_argument(
+            subparser.add_argument(
                 "pep",
                 metavar="PEP",
                 help="Path to a PEP configuration file in yaml format.",
                 default=None,
             )
         else:
-            sps[cmd].add_argument(
+            subparser.add_argument(
                 "pep",
                 metavar="PEP",
                 nargs="?",
                 help="Path to a PEP configuration file in yaml format.",
                 default=None,
             )
+
+        sps[cmd] = subparser
 
     sps[VALIDATE_CMD].add_argument(
         "-s",

--- a/eido/argparser.py
+++ b/eido/argparser.py
@@ -45,7 +45,22 @@ def build_argparser():
             "--st-index",
             required=False,
             type=str,
+            default=SAMPLE_NAME_ATTR,
             help=f"Sample table index to use, samples are identified by '{SAMPLE_NAME_ATTR}' by default.",
+        )
+        subparser.add_argument(
+            "--sst-index",
+            required=False,
+            type=str,
+            default=SAMPLE_NAME_ATTR,
+            help=f"Subsample table index to use, samples are identified by '{SAMPLE_NAME_ATTR}' by default.",
+        )
+        subparser.add_argument(
+            "--amendments",
+            required=False,
+            type=str,
+            nargs="+",
+            help=f"Names of the amendments to activate."
         )
         if cmd != CONVERT_CMD:
             subparser.add_argument(

--- a/eido/cli.py
+++ b/eido/cli.py
@@ -85,7 +85,9 @@ def main():
         else:
             paths = None
 
-        p = Project(args.pep, sample_table_index=args.st_index)
+        p = Project(args.pep, sample_table_index=args.st_index,
+                subsample_table_index=args.sst_index,
+                amendments=args.amendments)
         plugin_kwargs = _parse_filter_args_str(args.args)
 
         # append paths
@@ -97,7 +99,9 @@ def main():
 
     _LOGGER.debug(f"Creating a Project object from: {args.pep}")
     if args.command == VALIDATE_CMD:
-        p = Project(cfg=args.pep, sample_table_index=args.st_index)
+        p = Project(args.pep, sample_table_index=args.st_index,
+                subsample_table_index=args.sst_index,
+                amendments=args.amendments)
         if args.sample_name:
             try:
                 args.sample_name = int(args.sample_name)
@@ -121,6 +125,8 @@ def main():
         _LOGGER.info("Validation successful")
 
     if args.command == INSPECT_CMD:
-        p = Project(cfg=args.pep, sample_table_index=args.st_index)
+        p = Project(args.pep, sample_table_index=args.st_index,
+                subsample_table_index=args.sst_index,
+                amendments=args.amendments)
         inspect_project(p, args.sample_name, args.attr_limit)
         sys.exit(0)


### PR DESCRIPTION
Add support for `subsample_table_index` and `amendments` to the eido command line.

This allows eido to validate, filter and inspect based on amendments, and resolves #50 . 