### PR TITLE
Expose EidoValidationError

### DIFF
--- a/eido/__init__.py
+++ b/eido/__init__.py
@@ -23,4 +23,5 @@ __all__ = [
     "yaml_pep_filter",
     "csv_pep_filter",
     "yaml_samples_pep_filter",
+    "EidoValidationError",
 ]

--- a/eido/exceptions.py
+++ b/eido/exceptions.py
@@ -2,7 +2,7 @@
 
 from abc import ABCMeta
 
-_all__ = ["PathAttrNotFoundError", "EidoSchemaInvalidError", "EidoFilterError"]
+_all__ = ["EidoFilterError", "EidoSchemaInvalidError", "EidoValidationError", "PathAttrNotFoundError"]
 
 
 class EidoException(Exception):


### PR DESCRIPTION
Desire to access this name directly both...
a) seems logically reasonable
b) came up pragmatically in addressing looper test failure

Rather than improperly accessing this name through knowledge of the `eido` codebase structure, we should expose it as a top-level name.