### PR TITLE
Release pandas upper bound; fix float nan/None issue

### DIFF
--- a/eido/output_formatters.py
+++ b/eido/output_formatters.py
@@ -112,6 +112,11 @@ class MultilineOutputFormatter(BaseOutputFormatter):
             else:
                 value = sample.get(attribute)
 
+            if isinstance(value, float) and value != value:
+                # pandas (>=3.0) yields float('nan') instead of None for missing
+                # values when a Sample's attributes originate from a DataFrame
+                value = None
+
             sample_row.append(value or "")
 
         return ",".join(sample_row)

--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -1,6 +1,6 @@
 importlib-metadata; python_version < '3.10'
 jsonschema>=3.0.1
 logmuse>=0.2.5
-pandas<3.0.0
+pandas
 peppy>=0.40.7
 ubiquerg>=0.5.2


### PR DESCRIPTION
I'm working on getting pandas 3.0 supported on some downstream dependencies (including https://github.com/snakemake/snakemake/issues/4250) and came across this pin as a limitation. This was the only failure that I found when running the tests.

I've tested it both with pandas 2.3.3 and pandas 3.03 and all the tests are currently passing.

Closes: #84 